### PR TITLE
Implemented a showcase picker via the hash part of the url

### DIFF
--- a/core/src/main/java/com/epicness/alejandria/AlejandriaApp.java
+++ b/core/src/main/java/com/epicness/alejandria/AlejandriaApp.java
@@ -2,8 +2,10 @@ package com.epicness.alejandria;
 
 import com.badlogic.gdx.Game;
 import com.epicness.alejandria.interfacing.AlertSystem;
+import com.epicness.alejandria.interfacing.ShowcasePicker;
 import com.epicness.alejandria.showcase.ShowcaseInitializer;
 import com.epicness.alejandria.showcase.assets.ShowcaseAssets;
+import com.epicness.alejandria.showcase.logic.ShowcaseLogic;
 import com.epicness.fundamentals.SharedResources;
 
 // TODO: 2/29/2024 Show FPS (1/Delta or Gdx.graphics.getFramesPerSecond() and Delta Time when debug enabled
@@ -24,6 +26,7 @@ import com.epicness.fundamentals.SharedResources;
 public class AlejandriaApp extends Game {
 
     private AlertSystem alertSystem;
+    private ShowcasePicker showcasePicker;
 
     @Override
     public void create() {
@@ -31,7 +34,11 @@ public class AlejandriaApp extends Game {
         assets.queueAssetLoading();
         assets.finishLoading();
         assets.initializeAssets();
-        new ShowcaseInitializer(assets).initialize(new SharedResources());
+
+        var potentialShowcaseName = showcasePicker.getShowcase();
+        var showcaseInitializer = new ShowcaseInitializer(assets);
+        showcaseInitializer.initialize(new SharedResources());
+        ((ShowcaseLogic) showcaseInitializer.getLogic()).setShowcaseByName(potentialShowcaseName);
     }
 
     public AlertSystem getAlertSystem() {
@@ -40,5 +47,13 @@ public class AlejandriaApp extends Game {
 
     public void setAlertSystem(AlertSystem alertSystem) {
         this.alertSystem = alertSystem;
+    }
+
+    public void setShowcasePicker(ShowcasePicker showcasePicker) {
+        this.showcasePicker = showcasePicker;
+    }
+
+    public ShowcasePicker getShowcasePicker() {
+        return showcasePicker;
     }
 }

--- a/core/src/main/java/com/epicness/alejandria/interfacing/ShowcasePicker.java
+++ b/core/src/main/java/com/epicness/alejandria/interfacing/ShowcasePicker.java
@@ -1,0 +1,6 @@
+package com.epicness.alejandria.interfacing;
+
+public interface ShowcasePicker {
+    void setShowcase(String example);
+    String getShowcase();
+}

--- a/core/src/main/java/com/epicness/alejandria/showcase/logic/ShowcaseHandler.java
+++ b/core/src/main/java/com/epicness/alejandria/showcase/logic/ShowcaseHandler.java
@@ -108,7 +108,7 @@ public class ShowcaseHandler extends ShowcaseLogicHandler {
         }
     }
 
-    private void changeModule(int index) {
+    public void changeModule(int index) {
         if (currentModule != null) {
             currentModule.exitModule();
         }
@@ -116,6 +116,7 @@ public class ShowcaseHandler extends ShowcaseLogicHandler {
         stuff.getShowcase().setModuleDrawable(currentModule.setupModule());
         stuff.getTitle().setText(currentModule.title);
         stuff.getInformation().setText(currentModule.information);
+        game.getShowcasePicker().setShowcase(currentModule.getClass().getName());
         hideInformation();
     }
 

--- a/core/src/main/java/com/epicness/alejandria/showcase/logic/ShowcaseLogic.java
+++ b/core/src/main/java/com/epicness/alejandria/showcase/logic/ShowcaseLogic.java
@@ -145,4 +145,13 @@ public class ShowcaseLogic extends Logic {
     public void resize(int width, int height) {
         showcaseHandler.resize(width, height);
     }
+
+    public void setShowcaseByName(String potentialShowcaseName) {
+        for (int i = 0; i < getHandlers().size(); i++) {
+            if (potentialShowcaseName.equals(getHandlers().get(i).getClass().getName())) {
+                showcaseHandler.changeModule(i);
+                break;
+            }
+        }
+    }
 }

--- a/core/src/main/java/com/epicness/fundamentals/initializer/Initializer.java
+++ b/core/src/main/java/com/epicness/fundamentals/initializer/Initializer.java
@@ -81,4 +81,8 @@ public abstract class Initializer<A extends Assets, R extends Renderer<S>, S ext
     public boolean wasInitialized() {
         return initialized;
     }
+
+    public Logic getLogic() {
+        return logic;
+    }
 }

--- a/html/src/main/java/com/epicness/alejandria/gwt/GwtLauncher.java
+++ b/html/src/main/java/com/epicness/alejandria/gwt/GwtLauncher.java
@@ -22,6 +22,7 @@ public class GwtLauncher extends GwtApplication {
     public ApplicationListener createApplicationListener() {
         AlejandriaApp app = new AlejandriaApp();
         app.setAlertSystem(new HTMLAlertSystem());
+        app.setShowcasePicker(new HTMLShowcasePicker());
         return app;
     }
 }

--- a/html/src/main/java/com/epicness/alejandria/gwt/HTMLShowcasePicker.java
+++ b/html/src/main/java/com/epicness/alejandria/gwt/HTMLShowcasePicker.java
@@ -1,0 +1,20 @@
+package com.epicness.alejandria.gwt;
+
+import com.epicness.alejandria.interfacing.ShowcasePicker;
+import com.google.gwt.user.client.Window;
+
+public class HTMLShowcasePicker implements ShowcasePicker {
+    @Override
+    public void setShowcase(String showcase) {
+        updateHashNative(showcase);
+    }
+
+    @Override
+    public String getShowcase() {
+        return Window.Location.getHash().replace("#", "");
+    }
+
+    public static native void updateHashNative(String example) /*-{
+        $wnd.location.replace("#" + example);
+    }-*/;
+}


### PR DESCRIPTION
Hello! 

This adds two things:
* The currently viewed showcase to the URL
* And it reads that URL part on startup and displays the showcase.

This allows everyone to link to specific showcases instead of always starting at the beginning.

I have decided to use the full class name instead of simple indexes, just so you can reorder the modules at any time without destroying old links.

Here is a quick showcase:
https://github.com/user-attachments/assets/fb29f304-fb50-47a2-9794-7586de355628

